### PR TITLE
Fix: Replace hardcoded UUID with dynamically generated UUID in process_csv_to_description

### DIFF
--- a/mapilio_kit/components/processing/process_csv_to_description.py
+++ b/mapilio_kit/components/processing/process_csv_to_description.py
@@ -1,4 +1,5 @@
 import csv
+import uuid
 import json
 import os.path
 from mapilio_kit.components import version
@@ -36,7 +37,7 @@ def process_csv_to_description(
                 "processed_images": processed,
                 "failed_images": 0,
                 "duplicated_images": 0,
-                "id": "8323ff0a01fe49d1b55e610279f62828",
+                "id": str(uuid.uuid4()),
                 "device_type": "Desktop"
             }
         }


### PR DESCRIPTION
## Summary

This PR fixes a bug where a hardcoded UUID (`8323ff0a01fe49d1b55e610279f62828`) was used in the `description_information` dictionary within the `process_csv_to_description` function.

## Changes

1. Added `import uuid` to the imports section
2. Replaced the hardcoded UUID string with `str(uuid.uuid4())` to generate a unique UUID for each processing session

## Impact

- Each processing session will now have a unique identifier
- Ensures proper tracking of processed data
- Prevents potential conflicts when multiple sessions produce output with the same ID

## Testing

The fix can be verified by running the `process_csv_to_description` function multiple times and confirming that each execution produces a different UUID in the `mapilio_image_description.json` output file.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.