### PR TITLE
fix: use regex in get_latest_version() to handle any quote style

### DIFF
--- a/mapilio_kit/components/utilities/info.py
+++ b/mapilio_kit/components/utilities/info.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import time
 
@@ -38,10 +39,9 @@ def get_latest_version():
     url = "https://raw.githubusercontent.com/mapilio/mapilio-kit/main/mapilio_kit/components/version.py"
     response = requests.get(url)
     if response.status_code == 200:
-        content = response.text
-        version_line = [line for line in content.split('\n') if 'VERSION' in line][0]
-        latest_version = version_line.split('"')[1]
-        return latest_version
+        match = re.search(r"""VERSION\s*=\s*["']([^"']+)["']""", response.text)
+        if match:
+            return match.group(1)
     return None
 
 

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,0 +1,54 @@
+"""Regression tests for ``mapilio_kit.components.utilities.info.get_latest_version``.
+
+Covers the IndexError bug (GitHub issue #209) caused by a hard-coded quote
+delimiter that broke when version.py switched quote styles.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mapilio_kit.components.utilities.info import get_latest_version
+
+
+def _mock_response(text: str, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    return resp
+
+
+@pytest.mark.parametrize(
+    "version_py_content, expected",
+    [
+        ('VERSION = "3.0.6"', "3.0.6"),
+        ("VERSION = '3.0.5'", "3.0.5"),
+        ('VERSION = "3.1.0-beta"', "3.1.0-beta"),
+    ],
+)
+def test_get_latest_version_parses_both_quote_styles(
+    version_py_content: str, expected: str
+) -> None:
+    with patch(
+        "mapilio_kit.components.utilities.info.requests.get",
+        return_value=_mock_response(version_py_content),
+    ):
+        assert get_latest_version() == expected
+
+
+def test_get_latest_version_returns_none_on_http_error() -> None:
+    with patch(
+        "mapilio_kit.components.utilities.info.requests.get",
+        return_value=_mock_response("", status_code=404),
+    ):
+        assert get_latest_version() is None
+
+
+def test_get_latest_version_returns_none_when_no_version_line() -> None:
+    with patch(
+        "mapilio_kit.components.utilities.info.requests.get",
+        return_value=_mock_response("# no version here\n"),
+    ):
+        assert get_latest_version() is None


### PR DESCRIPTION
## Summary

Fixes #209.

`get_latest_version()` in `info.py` was parsing the version string by splitting on a hard-coded quote character (`split("'")` in older releases, `split('"')` in current `main`). When the quote style in `version.py` does not match, `split()` returns a one-element list and `[1]` raises `IndexError: list index out of range`.

- Replace the fragile `split()` approach with `re.search()` matching `VERSION = "…"` or `VERSION = '…'` — robust against any future quote-style change.
- Add `tests/test_info.py` with regression tests covering both quote styles, HTTP 404, and a missing `VERSION` line.

## Test plan

- [x] Existing 95 tests still pass (`pytest tests/ -q`)
- [x] 5 new regression tests added and passing (100 total)
- [x] Manually verified regex output against all three quote-style variants before applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)