### PR TITLE
fix: compute GoPro 360 crop params dynamically from image dimensions

### DIFF
--- a/mapilio_kit/components/geotagging/gps_from_gopro360.py
+++ b/mapilio_kit/components/geotagging/gps_from_gopro360.py
@@ -129,7 +129,16 @@ def gopro360max_stitch(video_file: str,
                        frame_rate: int,
                        output_folder: str,
                        quality: str,
-                       bin_dir: str):
+                       bin_dir: str) -> None:
+    """Extract, stitch, and geotag frames from a GoPro MAX 360 video.
+
+    Stitches dual-fisheye tracks into equirectangular JPEGs using
+    MAX2spherebatch, geotagges them from the video's GPS track, and
+    writes XMP projection metadata so panorama viewers can display them
+    correctly.  Crop parameters are computed dynamically from the actual
+    image dimensions, so any GoPro MAX recording resolution is handled
+    without hard-coding pixel counts.
+    """
     script_dir = os.path.dirname(os.path.realpath(__file__))
     frame_delta = 1.0 / frame_rate
     print(f"frame_delta: {frame_delta}")
@@ -219,16 +228,26 @@ def gopro360max_stitch(video_file: str,
     print(f"cmd: {cmd}")
     run_command(cmd, show_progress=False)
 
-    cmd = f"exiftool -CameraElevationAngle=360 " \
-          f"-make=GoPro " \
-          f"-model=Max " \
-          f"-ProjectionType=equirectangular " \
-          f"-UsePanoramaViewer=True " \
-          f"-CroppedAreaImageWidthPixels=4096 " \
-          f"-CroppedAreaImageHeightPixels=1344 " \
-          f"-FullPanoWidthPixels=4096 " \
-          f"-FullPanoHeightPixels=1344 " \
-          f"-CroppedAreaLeftPixels=0 -CroppedAreaTopPixels=0 {frames_folder}"
+    # Use exiftool computed-value syntax to derive crop parameters from
+    # the actual image dimensions.  Hard-coding 4096×1344 only works for
+    # one specific GoPro Max recording mode; this adapts to any output
+    # resolution (e.g. 4096×2048 for full-equirectangular exports).
+    # CroppedAreaTopPixels = (ImageWidth/2 - ImageHeight) / 2
+    cmd = (
+        f"exiftool -CameraElevationAngle=360 "
+        f"-make=GoPro "
+        f"-model=Max "
+        f"-ProjectionType=equirectangular "
+        f"-UsePanoramaViewer=True "
+        f"'-CroppedAreaImageWidthPixels<$ImageWidth' "
+        f"'-CroppedAreaImageHeightPixels<$ImageHeight' "
+        f"'-FullPanoWidthPixels<$ImageWidth' "
+        f"'-FullPanoHeightPixels<$ImageHeight' "
+        f"-CroppedAreaLeftPixels=0 "
+        f"'-CroppedAreaTopPixels<${{ImageWidth;$_=($_/2"
+        f"-$self->GetValue(\"ImageHeight\"))/2}}' "
+        f"{frames_folder}"
+    )
     print(f"cmd: {cmd}")
     run_command(cmd, show_progress=False)
     remove_files(frames_folder, "*.jpg_original")


### PR DESCRIPTION
## Summary

- Replaces hard-coded `4096×1344` pixel values in the exiftool XMP-tagging step of `gopro360max_stitch()` with exiftool's computed-value syntax, so `CroppedArea` and `FullPano` tags are derived from the actual `ImageWidth`/`ImageHeight` at write time
- Adds a docstring to `gopro360max_stitch()` explaining the pipeline stages and the dynamic crop approach
- Formula: `CroppedAreaTopPixels = (ImageWidth / 2 − ImageHeight) / 2`

Closes #200

## Why the hard-coded values break

The original command assumes every GoPro MAX export is `4096×1344 px`. GoPro MAX can also output `4096×2048` (full equirectangular), which causes incorrect XMP metadata and panorama viewer misalignment. The fix uses exiftool's `${TAG;EXPR}` computed-value syntax to read the actual dimensions from each frame and derive the correct crop offsets dynamically.

## Testing

The existing test suite (95 tests) passes. `gopro360max_stitch()` requires external binaries (`MAX2spherebatch`, `ffpb`, `exiftool`) and real GoPro MAX footage, so it cannot be run in CI. The exiftool command string was verified correct against the documented computed-value syntax, and the formula was taken directly from the approach proposed by the original reporter in #200, who confirmed it works on their `4096×2048` footage. **Maintainer verification on real GoPro MAX hardware is recommended before merging.**

## Test plan

- [ ] Run `gopro360max_stitch()` against a `4096×1344` GoPro MAX clip — verify XMP metadata and panorama viewer display are unchanged
- [ ] Run against a `4096×2048` clip (issue #200 reproduction case) — verify correct crop offsets and panorama viewer alignment
- [ ] `python -m pytest tests/` passes (95 tests, no GoPro hardware required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)